### PR TITLE
Update orgHelper.py

### DIFF
--- a/python/subscripts/orgHelper.py
+++ b/python/subscripts/orgHelper.py
@@ -113,7 +113,7 @@ def createScratchOrg_pushMetadata(term):
 def createScratchOrg_pushNonDeployedMetadata(term):
 	path = helper.getConfig('locations.unpackagable')
 	
-	if (path is None):
+	if (path is None or (helper.folderExists(path) and len(os.listdir(path)) == 0)):
 		return False, []
 	
 	if (not helper.folderExists(path)):


### PR DESCRIPTION
SFDX cli fails on empty source push. Added extra check that push is only performed if folder is not empty.